### PR TITLE
feat: Integrate APIBridge with FastAPI for Slack APIs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from api_bridge import APIBridge
+
+# Single database configuration
+db_config = {
+    "host": "localhost",
+    "port": 3306,
+    "database": "slack_db",
+    "user": "root",
+    "password": "1234"
+}
+
+app = FastAPI(
+    title="Slack"
+)
+
+api_bridge = APIBridge(db_config,base_endpoint="/slack-apis")
+app.include_router(api_bridge.router)
+
+# Run the app
+# uvicorn main:app --reload

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+smart-api-bridge


### PR DESCRIPTION
- Configured FastAPI application with a base endpoint `/slack-apis`.  
- Initialized `APIBridge` with MySQL database configuration.  
- Included the API router in the FastAPI app. 